### PR TITLE
use bindless resources and root constants (d3d12/vulkan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ download and run the application.
     * Direct3D 11
     * Direct3D 12
     * OpenGL (may experience driver issues on Intel graphics)
-    * Vulkan (may experience driver issues on Intel graphics)
+    * Vulkan
 * Physically Based Rendering (PBR) with support for albedo, metallic-roughness,
   normal, and emissive textures
 * Normal mapping
@@ -32,6 +32,7 @@ download and run the application.
 * Mouse/keyboard and gamepad controls for model selection, rotation, zoom, etc.
 * UI for displaying model names, performance metrics, etc.
 * Ultrawide support
+* Bindless rendering (D3D12/Vulkan only)
 
 ## Models
 The included 3D models are processed from their original glTF 2.0 binary format

--- a/build.bat
+++ b/build.bat
@@ -84,26 +84,28 @@ if defined all (
 
     rem -Zpr: Pack matrices in row-major
     rem -Ges: Enable strict mode
-    set fxc_flags=-Zpr -Ges
+    rem -enable_unbounded_descriptor_tables: Enable use of unbounded arrays (D3D12 only)
+    set fxc_flags=-Zpr -Ges -enable_unbounded_descriptor_tables
     if defined release (
         rem -O3: Enable optimizations
-        rem -all_resources_bound: Optimize out unbound resource checks
         rem -Qstrip_debug: Strip debug data
         rem -Qstrip_priv: Strip private data
         rem -Qstrip_reflect: Strip reflection data
-        set fxc_flags=!fxc_flags! -O3 -all_resources_bound -Qstrip_debug -Qstrip_priv -Qstrip_reflect
+        rem -all_resources_bound: Optimize out unbound resource checks (D3D12 only)
+        set fxc_flags=!fxc_flags! -O3 -Qstrip_debug -Qstrip_priv -Qstrip_reflect -all_resources_bound
     ) else (
         rem -Od: Disable optimizations
         rem -Zi: Enable debug info
         set fxc_flags=!fxc_flags! -Od -Zi
     )
+    rem -D: Set preprocessor macro
     rem -E: Set entrypoint name
     rem -T: Set shader target profile
     rem -Fo: Set output file path
-    fxc shaders.hlsl !fxc_flags! -E vs -T vs_5_0 -Fo build\shaders\d3d11_vs.dxbc > nul
-    fxc shaders.hlsl !fxc_flags! -E ps -T ps_5_0 -Fo build\shaders\d3d11_ps.dxbc > nul
-    fxc shaders.hlsl !fxc_flags! -E vs -T vs_5_1 -Fo build\shaders\d3d12_vs.dxbc > nul
-    fxc shaders.hlsl !fxc_flags! -E ps -T ps_5_1 -Fo build\shaders\d3d12_ps.dxbc > nul
+    fxc shaders.hlsl !fxc_flags! -DD3D11 -E vs -T vs_5_0 -Fo build\shaders\d3d11_vs.dxbc > nul
+    fxc shaders.hlsl !fxc_flags! -DD3D11 -E ps -T ps_5_0 -Fo build\shaders\d3d11_ps.dxbc > nul
+    fxc shaders.hlsl !fxc_flags! -DD3D12 -E vs -T vs_5_1 -Fo build\shaders\d3d12_vs.dxbc > nul
+    fxc shaders.hlsl !fxc_flags! -DD3D12 -E ps -T ps_5_1 -Fo build\shaders\d3d12_ps.dxbc > nul
 
     rem -Zpr: Pack matrices in row-major
     rem -Ges: Enable strict mode
@@ -112,25 +114,26 @@ if defined all (
     set dxc_flags=-Zpr -Ges -spirv -fvk-use-dx-layout
     if defined release (
         rem -O3: Enable optimizations
-        rem -all-resources-bound: Optimize out unbound resource checks
         rem -Qstrip_debug: Strip debug data
         rem -Qstrip_priv: Strip private data
         rem -Qstrip_reflect: Strip reflection data (NOTE: not supported with -spirv)
-        set dxc_flags=!dxc_flags! -O3 -all-resources-bound -Qstrip_debug -Qstrip_priv
+        rem -all-resources-bound: Optimize out unbound resource checks
+        set dxc_flags=!dxc_flags! -O3 -Qstrip_debug -Qstrip_priv -all-resources-bound
     ) else (
         rem -Od: Disable optimizations
         rem -Zi: Enable debug info
         rem -fspv-debug=vulkan-with-source: Enable source-level debugging
         set dxc_flags=!dxc_flags! -Od -Zi -fspv-debug=vulkan-with-source
     )
+    rem -D: Set preprocessor macro
     rem -E: Set entrypoint name
     rem -T: Set shader target profile
     rem -Fo: Set output file path
     rem -vkbr a b c d: Assign HLSL register (a) in space (b) to binding (c) in descriptor set (d)
-    !dxc! shaders.hlsl !dxc_flags! -E vs -T vs_6_0 -Fo build\shaders\gl_vs.spv -vkbr b0 0 0 0 -vkbr b1 0 1 0 -vkbr b2 0 2 0 -vkbr t0 0 0 0 -vkbr t1 0 1 0 -vkbr t2 0 2 0 -vkbr t3 0 3 0 -vkbr s0 0 3 0
-    !dxc! shaders.hlsl !dxc_flags! -E ps -T ps_6_0 -Fo build\shaders\gl_ps.spv -vkbr b0 0 0 0 -vkbr b1 0 1 0 -vkbr b2 0 2 0 -vkbr t0 0 0 0 -vkbr t1 0 1 0 -vkbr t2 0 2 0 -vkbr t3 0 3 0 -vkbr s0 0 3 0
-    !dxc! shaders.hlsl !dxc_flags! -E vs -T vs_6_0 -Fo build\shaders\vk_vs.spv -vkbr b0 0 0 0 -vkbr b1 0 1 0 -vkbr b2 0 2 0 -vkbr t0 0 3 0 -vkbr t1 0 4 0 -vkbr t2 0 5 0 -vkbr t3 0 6 0 -vkbr s0 0 7 0
-    !dxc! shaders.hlsl !dxc_flags! -E ps -T ps_6_0 -Fo build\shaders\vk_ps.spv -vkbr b0 0 0 0 -vkbr b1 0 1 0 -vkbr b2 0 2 0 -vkbr t0 0 3 0 -vkbr t1 0 4 0 -vkbr t2 0 5 0 -vkbr t3 0 6 0 -vkbr s0 0 7 0
+    !dxc! shaders.hlsl !dxc_flags! -DOPENGL -E vs -T vs_6_0 -Fo build\shaders\gl_vs.spv -vkbr b0 0 0 0 -vkbr b1 0 1 0 -vkbr t0 0 0 0 -vkbr t1 0 1 0 -vkbr t2 0 2 0 -vkbr t3 0 3 0 -vkbr s0 0 3 0
+    !dxc! shaders.hlsl !dxc_flags! -DOPENGL -E ps -T ps_6_0 -Fo build\shaders\gl_ps.spv -vkbr b0 0 0 0 -vkbr b1 0 1 0 -vkbr t0 0 0 0 -vkbr t1 0 1 0 -vkbr t2 0 2 0 -vkbr t3 0 3 0 -vkbr s0 0 3 0
+    !dxc! shaders.hlsl !dxc_flags! -DVULKAN -E vs -T vs_6_0 -Fo build\shaders\vk_vs.spv -vkbr b0 0 0 0 -vkbr b1 0 1 0 -vkbr t0 0 2 0 -vkbr t1 0 3 0 -vkbr t2 0 4 0 -vkbr t3 1 6 0 -vkbr s0 0 5 0
+    !dxc! shaders.hlsl !dxc_flags! -DVULKAN -E ps -T ps_6_0 -Fo build\shaders\vk_ps.spv -vkbr b0 0 0 0 -vkbr b1 0 1 0 -vkbr t0 0 2 0 -vkbr t1 0 3 0 -vkbr t2 0 4 0 -vkbr t3 1 6 0 -vkbr s0 0 5 0
 
     rem Asset Compilation
     asset_compiler


### PR DESCRIPTION
This change also fixes Vulkan rendering on Intel GPUs. The Vulkan renderer now uses bindless textures and one descriptor set, so it no longer depends on `VK_KHR_push_descriptor`, which didn't work on Intel due to driver issues.